### PR TITLE
Don't run check when requested not to

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,24 @@ jobs:
           configure:
           check: true
           install: true
+
+  build_wolfssl_no_check:
+    strategy:
+      matrix:
+        runs-on: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.runs-on }}
+
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v3
+
+      - name: Build wolfSSL
+        uses: ./
+        with:
+          repository: wolfSSL/wolfssl
+          ref: master
+          path: wolfssl
+          configure:
+          check: false
+          install: false
+

--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,13 @@ inputs:
     default: '' 
   check:
     description: 'Should we run make check.'
+    # Force it to string because of https://github.com/actions/runner/issues/1483
+    type: string
     default: true
   install:
     description: 'Should we run make install. Installs to $GITHUB_WORKSPACE/build-dir.'
+    # Force it to string because of https://github.com/actions/runner/issues/1483
+    type: string
     default: false
   patch-file:
     description: 'The patch file to use when we are building an OSP project.'
@@ -89,7 +93,7 @@ runs:
       - shell: bash
         id: check
         working-directory: ${{ inputs.path }}
-        if: inputs.check
+        if: ${{ inputs.check == 'true' }}
         run: make check
 
       # Print errors 
@@ -104,6 +108,6 @@ runs:
       # Install
       - shell: bash
         working-directory: ${{ inputs.path }}
-        if: inputs.install
+        if: ${{ inputs.install == 'true' }}
         run: make install
 


### PR DESCRIPTION
Github actions suffer the javascript pain of vague types. As a result `check: false` was not disabling the tests. This is sometimes necessary when we just want to run a subset of the tests. For more context: https://github.com/actions/runner/issues/1483